### PR TITLE
chore(gh): add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "daily"


### PR DESCRIPTION
Adds dependabot configuration.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>