### PR TITLE
Made MemorySharesValue in SDDC's ResourcePoolSpec а required field and add release v0.1.3 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v0.1.3](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.1.3)
+
+> Release Date: 02 Oct 2023
+
+Made MemorySharesValue in SDDC's ResourcePoolSpec а required field.
+
 ## [v0.1.2](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.1.2)
 
 > Release Date: 02 Oct 2023

--- a/models/resource_pool_spec.go
+++ b/models/resource_pool_spec.go
@@ -64,7 +64,7 @@ type ResourcePoolSpec struct {
 	MemorySharesLevel string `json:"memorySharesLevel,omitempty"`
 
 	// Memory shares value, only required when shares level is '0'
-	MemorySharesValue int32 `json:"memorySharesValue,omitempty"`
+	MemorySharesValue int32 `json:"memorySharesValue"`
 
 	// Resource Pool name
 	// Required: true


### PR DESCRIPTION

Tested that MemorySharesValue is serialized in the SDDCSpec JSON and VCF bringup API is correctly invoked.

Added dates for new release in the CHANGELOG.md

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/vcf-sdk-go/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**

Made MemorySharesValue in SDDC's ResourcePoolSpec а required field and add release v0.1.3 in CHANGELOG.md

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [X] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
