### PR TITLE
[fix] Autorotate policy was send as empty struct when disabled

### DIFF
--- a/models/auto_rotate_credential_policy_input_spec.go
+++ b/models/auto_rotate_credential_policy_input_spec.go
@@ -11,8 +11,10 @@ package models
 import (
 	"context"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // AutoRotateCredentialPolicyInputSpec Represents password auto rotate config details
@@ -21,7 +23,8 @@ import (
 type AutoRotateCredentialPolicyInputSpec struct {
 
 	//  Enable or disable  auto rotate policy
-	EnableAutoRotatePolicy bool `json:"enableAutoRotatePolicy,omitempty"`
+	// Required: true
+	EnableAutoRotatePolicy *bool `json:"enableAutoRotatePolicy"`
 
 	// Frequency in days
 	FrequencyInDays int32 `json:"frequencyInDays,omitempty"`
@@ -29,6 +32,24 @@ type AutoRotateCredentialPolicyInputSpec struct {
 
 // Validate validates this auto rotate credential policy input spec
 func (m *AutoRotateCredentialPolicyInputSpec) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateEnableAutoRotatePolicy(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *AutoRotateCredentialPolicyInputSpec) validateEnableAutoRotatePolicy(formats strfmt.Registry) error {
+
+	if err := validate.Required("enableAutoRotatePolicy", "body", m.EnableAutoRotatePolicy); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -21413,6 +21413,7 @@
       "description" : "Represents a page of elements of a single type"
     },
     "AutoRotateCredentialPolicyInputSpec" : {
+      "required" : [ "enableAutoRotatePolicy" ],
       "properties" : {
         "enableAutoRotatePolicy" : {
           "type" : "boolean",


### PR DESCRIPTION


**Summary of Pull Request**

When EnableAutoRotatePolicy and FrequencyInDays are respectively false and 0 AutoRotateCredentialPolicyInputSpec was serialized as empty object causing API error. This servers the case when the autorotate policy for credential has to be disabled i.e. EnableAutoRotatePolicy is false. Having the omitempty attrbute does not send the value over the wire.

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/vcf-sdk-go/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
