### PR TITLE
Make GeneveVlanID a required field and bump project version in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v0.2.3](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.2.3)
+
+> Release Date: 27 Feb 2024
+
+Made GeneveVlanID in NsxTClusterSpec а required field.
+
 ## [v0.2.2](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.2.2)
 
 > Release Date: 11 Dec 2023

--- a/models/nsx_t_cluster_spec.go
+++ b/models/nsx_t_cluster_spec.go
@@ -22,7 +22,7 @@ import (
 type NsxTClusterSpec struct {
 
 	// Vlan id of Geneve
-	GeneveVlanID int32 `json:"geneveVlanId,omitempty"`
+	GeneveVlanID int32 `json:"geneveVlanId"`
 
 	// The IP address pool specification
 	IPAddressPoolSpec *IPAddressPoolSpec `json:"ipAddressPoolSpec,omitempty"`


### PR DESCRIPTION
**Summary of Pull Request**

The "GeneveVlanID" field in nsx_t_cluster_spec.go is marked as optional which results in incorrect serialization when the SDK is used.
See https://github.com/vmware/terraform-provider-vcf/issues/128 for more details

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

https://github.com/vmware/terraform-provider-vcf/issues/128

**Test and Documentation Coverage**

For bug fixes or features:

- [ ] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

