### PR TITLE
Accept 0 as a valid VLAN ID for network pools and edge node managemen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v0.3.1](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.1)
+
+> Release Date: 03 June 2024
+
+Accept 0 as a valid VLAN ID for network pools and edge node management portgroups
+
 ## [v0.3.0](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.0)
 
 > Release Date: 23 May 2024

--- a/models/network.go
+++ b/models/network.go
@@ -50,7 +50,7 @@ type Network struct {
 	UsedIps []string `json:"usedIps"`
 
 	// VLAN ID associated with the network
-	VlanID int32 `json:"vlanId,omitempty"`
+	VlanID int32 `json:"vlanId"`
 }
 
 // Validate validates this network

--- a/models/nsx_t_edge_node_spec.go
+++ b/models/nsx_t_edge_node_spec.go
@@ -74,7 +74,7 @@ type NsxTEdgeNodeSpec struct {
 	VMManagementPortgroupName string `json:"vmManagementPortgroupName,omitempty"`
 
 	// Management Vlan Id
-	VMManagementPortgroupVlan int32 `json:"vmManagementPortgroupVlan,omitempty"`
+	VMManagementPortgroupVlan int32 `json:"vmManagementPortgroupVlan"`
 }
 
 // Validate validates this nsx t edge node spec


### PR DESCRIPTION
**Summary of Pull Request**

When a property's JSON key is marked with "omitempty" Golang skips zeroes and empty strings when marshalling objects into JSON.

Since 0 is a valid VLAN ID I am removing the "omitempty" marker from a couple of affected properties.

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

https://github.com/vmware/terraform-provider-vcf/issues/175


**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

