### PR TITLE
Revert "Accept 0 as a valid VLAN ID for network pools and edge node managemen…"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # CHANGELOG
 
-## [v0.3.1](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.1)
-
-> Release Date: 03 June 2024
-
-Accept 0 as a valid VLAN ID for network pools and edge node management portgroups
-
 ## [v0.3.0](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.0)
 
 > Release Date: 23 May 2024

--- a/models/network.go
+++ b/models/network.go
@@ -50,7 +50,7 @@ type Network struct {
 	UsedIps []string `json:"usedIps"`
 
 	// VLAN ID associated with the network
-	VlanID int32 `json:"vlanId"`
+	VlanID int32 `json:"vlanId,omitempty"`
 }
 
 // Validate validates this network

--- a/models/nsx_t_edge_node_spec.go
+++ b/models/nsx_t_edge_node_spec.go
@@ -74,7 +74,7 @@ type NsxTEdgeNodeSpec struct {
 	VMManagementPortgroupName string `json:"vmManagementPortgroupName,omitempty"`
 
 	// Management Vlan Id
-	VMManagementPortgroupVlan int32 `json:"vmManagementPortgroupVlan"`
+	VMManagementPortgroupVlan int32 `json:"vmManagementPortgroupVlan,omitempty"`
 }
 
 // Validate validates this nsx t edge node spec


### PR DESCRIPTION
Reverts vmware/vcf-sdk-go#40