### PR TITLE
Accept 0 as a valid VLAN ID for network pools and edge node management portgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [v0.3.1](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.1)
 
-> Release Date: 03 June 2024
+> Release Date: 07 June 2024
 
 Accept 0 as a valid VLAN ID for network pools and edge node management portgroups
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v0.3.1](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.1)
+
+> Release Date: 03 June 2024
+
+Accept 0 as a valid VLAN ID for network pools and edge node management portgroups
+
 ## [v0.3.0](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.0)
 
 > Release Date: 23 May 2024

--- a/models/network.go
+++ b/models/network.go
@@ -50,7 +50,7 @@ type Network struct {
 	UsedIps []string `json:"usedIps"`
 
 	// VLAN ID associated with the network
-	VlanID int32 `json:"vlanId,omitempty"`
+	VlanID int32 `json:"vlanId"`
 }
 
 // Validate validates this network

--- a/models/nsx_t_edge_node_spec.go
+++ b/models/nsx_t_edge_node_spec.go
@@ -71,10 +71,10 @@ type NsxTEdgeNodeSpec struct {
 	UplinkNetwork []*NsxTEdgeUplinkNetwork `json:"uplinkNetwork"`
 
 	// Management Network Name
-	VMManagementPortgroupName string `json:"vmManagementPortgroupName,omitempty"`
+	VMManagementPortgroupName *string `json:"vmManagementPortgroupName"`
 
 	// Management Vlan Id
-	VMManagementPortgroupVlan int32 `json:"vmManagementPortgroupVlan,omitempty"`
+	VMManagementPortgroupVlan *int32 `json:"vmManagementPortgroupVlan"`
 }
 
 // Validate validates this nsx t edge node spec


### PR DESCRIPTION
**Summary of Pull Request**

0 is a valid value for a VLAN ID. Optional properties in the API bindings get marked with `omitempty` and since 0 is the "empty value" for integers in Golang these properties are not included in the marshalled payload.

The fix for this is to simply remove the `omitempty` part from the JSON annotation for such properties.
If the target property is an integer in will always default to 0 if not specified by the user. This is okay for required properties.
If the target property is a pointer to an integer it will default to nil which is the desired behavior for optional properties.

The VLAN ID for network pools is required (this will be updated in the provider too) and the management network VLAN ID for edge nodes is optional. That is why the former is int32 and the latter is *int32

**Type of Pull Request**

Ran the acceptance tests for network pools and edge clusters in the terraform provider with both the default values and with modified settings to test 0 and empty VLAN IDs

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

https://github.com/vmware/terraform-provider-vcf/issues/147

https://github.com/vmware/terraform-provider-vcf/issues/175

**Test and Documentation Coverage**

For bug fixes or features:

- [X] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

