### PR TITLE
Fix vSAN ESA config serialization when value is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # CHANGELOG
 
-## [v0.3.1](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.1)
+## [v0.3.3](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.3)
+
+> Release Date: 24 July 2024
+
+Fix vSAN ESA config serialization when value is false
+
+## [v0.3.2](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.2)
 
 > Release Date: 07 June 2024
 
 Accept 0 as a valid VLAN ID for network pools and edge node management portgroups
+
+## [v0.3.1](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.1)
+
+> Release Date: 07 June 2024
+
+Do not use this release. Use v0.3.2 instead.
 
 ## [v0.3.0](https://github.com/vmware/vcf-sdk-go/releases/tag/v0.3.0)
 

--- a/models/vsan_esa_config.go
+++ b/models/vsan_esa_config.go
@@ -11,8 +11,10 @@ package models
 import (
 	"context"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // VSANEsaConfig This spec contains cluster vSAN ESA configuration
@@ -21,11 +23,30 @@ import (
 type VSANEsaConfig struct {
 
 	// Whether the vSAN ESA is enabled.
-	Enabled bool `json:"enabled,omitempty"`
+	// Required: true
+	Enabled *bool `json:"enabled"`
 }
 
 // Validate validates this Vsan esa config
 func (m *VSANEsaConfig) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateEnabled(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *VSANEsaConfig) validateEnabled(formats strfmt.Registry) error {
+
+	if err := validate.Required("enabled", "body", m.Enabled); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -20032,6 +20032,7 @@
       "description" : "Spec contains parameters of Virtual SAN"
     },
     "VsanEsaConfig" : {
+      "required" : [ "enabled" ],
       "properties" : {
         "enabled" : {
           "type" : "boolean",


### PR DESCRIPTION
**Summary of Pull Request**

The `Enabled` property on `VSANEsaConfig` is marked with "omitempty" which results in an invalid structure when the value is set to false.

The fix is to simply mark the property as required and regenerate the bindings.
It is still possible to omit the ESA configuration if necessary by not populating the containing structure.

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

This was reported internally

Issue Number: N/A

**Test and Documentation Coverage**

Tested by running `terraform-provider-vcf` and validating the bringup configuration in 3 scenarios
`esa_enabled = true`
`esa_enabled = false`
and with `esa_enabled` not present in the configuration.

For bug fixes or features:

- [X] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
