### PR TITLE
chore: bump golang to 1.26.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A Go SDK for the VMware Cloud Foundation.
 
 Required if building the SDK.
 
-* [Go][golang-install] v1.22.5
-* [oapi-codegen](https://github.com/oapi-codegen/runtime) v1.1.1
+* [Go][golang-install] v1.26.3
+* [oapi-codegen](https://github.com/oapi-codegen/runtime) v1.4.0
 
 ### Generate the SDK
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/vcf-sdk-go
 
-go 1.24.0
+go 1.26.3
 
 require github.com/oapi-codegen/runtime v1.4.0
 


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/vcf-sdk-go/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**

Bumping Golang to consume the security fixes from 1.26.2 and 1.26.3

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [X] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
